### PR TITLE
Added cache functionality when training decoder ONLY

### DIFF
--- a/src/fmtk/embedding_cache.py
+++ b/src/fmtk/embedding_cache.py
@@ -1,0 +1,46 @@
+import torch
+
+class EmbeddingCache:
+    """
+    Dynamic cache for backbone embeddings keyed by dataset index.
+    Size and embed_dim are inferred from the first put(); supports batched get/put.
+
+    #TODO: 1. The cache is currently saved on the CPU, we need logic to save it on disk 
+    # and fetch it if it gets too large. 
+    """
+    def __init__(self, cache_device = "cpu", to_device = "cpu"):
+        self._cache = {}
+        self._cache_device = cache_device
+        self._to_device = to_device
+
+    def __len__(self):
+        return len(self._cache)
+
+    def put(self, idx, value):
+        value = value.detach()
+        for i in range(len(idx)):
+            self._cache[idx[i].item()] = value[i].to(self._cache_device)
+
+    def contains(self, idx):
+        return all([k.item() in self._cache for k in idx])
+
+    def get(self, idx, device = None):   
+        device = device or self._to_device
+        return torch.stack([self._cache[k.item()].to(device) for k in idx], dim=0)
+    
+    def save(self, path):
+        # TODO: Very inefficient way to save the cache, 
+        # A better way is to store sharded files for the cache.
+        torch.save({"cache": self._cache}, path)
+
+    def load(self, path, map_location = None):
+        data = torch.load(path, map_location=map_location or str(self._cache_device))
+        self._cache = data["cache"]
+
+    def __str__(self):
+        intro = f"EmbeddingCache(cache_size={len(self._cache)})"
+        intro += f"\nCache: {list(self._cache.keys())}"
+        return intro
+
+    def __repr__(self):
+        return self.__str__()

--- a/src/fmtk/pipeline.py
+++ b/src/fmtk/pipeline.py
@@ -7,6 +7,7 @@ import os
 from contextlib import nullcontext
 import json
 from huggingface_hub import hf_hub_download
+from fmtk.embedding_cache import EmbeddingCache
 
 class Pipeline:
     def __init__(self, model_instance,logger=None):
@@ -20,7 +21,8 @@ class Pipeline:
         self.adapter_id=0
         self.encoder_id=0
         self.base_dir = os.path.dirname(__file__)
-        
+        self.embedding_cache = EmbeddingCache(cache_device='cpu', to_device=self.model_instance.device)
+
     def add_adapter(self,peft_cfg):
         adapter_name=f'adapter_{self.adapter_id}'
         self.adapter_id+=1
@@ -31,12 +33,10 @@ class Pipeline:
         else:
             self.model_instance.enable_peft(peft_cfg)
             return 'default'
-        
+
     def unload_adapter(self):
         if hasattr(self.model_instance,'peft_enable') and self.model_instance.peft_enable:
             self.model_instance.disable_adapters()
-
-
 
     def add_encoder(self,encoder_obj,load=True):
         encoder_name=f'encoder_{self.encoder_id}'
@@ -46,10 +46,10 @@ class Pipeline:
         if load:
             self.active_encoder = self.encoders[encoder_name]
         return f"{encoder_name}"
-    
+
     def unload_encoder(self):
         self.active_encoder=None
-    
+
     def add_decoder(self,decoder_obj,load=True,train=True,path=None):
         """Adds a named decoder to the manager."""
         decoder_name=f"decoder_{self.decoder_id}"
@@ -68,7 +68,7 @@ class Pipeline:
                     except Exception as e:
                         raise ValueError(f"Decoder file not found at {decoder_file}")
                 self.decoders[decoder_name].model.load_state_dict(torch.load(f"{decoder_file}"))
-                
+
             else:
                 self.decoders[decoder_name] = decoder_obj
             self.decoder_id+=1
@@ -87,7 +87,7 @@ class Pipeline:
                 if self.active_decoder is not None:
                     self.active_decoder.to_cpu()
                 self.decoders[decoder_id].to_device()
-                
+
             self.active_decoder = self.decoders[decoder_id]
 
     def unload_decoder(self):
@@ -135,26 +135,34 @@ class Pipeline:
                 if len(dec_params):
                     param_groups.append({"params": dec_params, "lr": cfg['lr']})   
 
+        # 1. If only training decoder, and 2. use_cache is True, then use cache
+        use_cache = (
+            trains_decoder
+            and not trains_adapter
+            and not trains_encoder
+            and cfg.get("use_cache", False)
+        )
         with (self.logger.measure("train", device=self.logger.device) if self.logger else nullcontext()):
             optimizer = torch.optim.Adam(param_groups)
             criterion = getattr(self.active_decoder, "criterion")
             for _ in range(cfg['epochs']):
                 for batch in tqdm(train_loader):
-                        optimizer.zero_grad()
-                        x, y = batch["x"], batch["y"]
-                        mask = batch.get("mask", None)
-                        logits=self.forward(x,mask)
-                        if (hasattr(self.active_decoder, "requires_model") and self.active_decoder.requires_model and hasattr(self.model_instance.model, "normalizer")):
-                            logits = self.model_instance.model.normalizer(x=logits, mode="denorm")
-                        if isinstance(criterion, (nn.MSELoss, nn.L1Loss, nn.SmoothL1Loss)): 
-                            logits = logits.float()
-                            y = y.to(self.active_decoder.device).float() 
-                        elif isinstance(criterion, (nn.CrossEntropyLoss)): 
-                            y = y.to(self.active_decoder.device)            
-                        loss = criterion(logits, y)
-                        loss.backward()
-                        optimizer.step()
-        
+                    optimizer.zero_grad()
+                    x, y = batch["x"], batch["y"]
+                    idx = batch.get("idx", None)
+                    mask = batch.get("mask", None)
+                    logits=self.forward(x,mask,use_cache=use_cache,idx=idx)
+                    if (hasattr(self.active_decoder, "requires_model") and self.active_decoder.requires_model and hasattr(self.model_instance.model, "normalizer")):
+                        logits = self.model_instance.model.normalizer(x=logits, mode="denorm")
+                    if isinstance(criterion, (nn.MSELoss, nn.L1Loss, nn.SmoothL1Loss)): 
+                        logits = logits.float()
+                        y = y.to(self.active_decoder.device).float() 
+                    elif isinstance(criterion, (nn.CrossEntropyLoss)): 
+                        y = y.to(self.active_decoder.device)            
+                    loss = criterion(logits, y)
+                    loss.backward()
+                    optimizer.step()
+
         category = self.model_instance.model_category
         os.makedirs(f"{self.base_dir}/../../models/{category}/finetuned/{path}",exist_ok=True)
         if trains_decoder:
@@ -182,12 +190,23 @@ class Pipeline:
             model.eval()
         else:
             return
-    
-    def forward(self,x,mask=None):
+
+    def forward(self,x,mask=None,use_cache=False,idx=None):
         if self.active_encoder is not None:
             x= self.active_encoder.forward(x)
         self.set_eval_mode()
-        feats=self.model_instance.forward(x,mask)
+        
+        if use_cache and idx is not None:
+            # TODO: Add functionality to partially use cache
+            # if only some of the idx are present
+            if self.embedding_cache.contains(idx):  # currently all idx need to be present in the cache
+                feats = self.embedding_cache.get(idx)
+            else:
+                feats = self.model_instance.forward(x, mask)
+                self.embedding_cache.put(idx, feats)
+        else:
+            feats = self.model_instance.forward(x, mask)
+    
         logits = self.active_decoder.forward((feats))
         return logits 
 
@@ -203,7 +222,7 @@ class Pipeline:
                         return self.active_decoder.predict(self.model_instance.model, test_embed_loader)
                     else:
                         return self.active_decoder.predict(test_embed_loader)
-                        
+
             else:
                 preds=[]
                 labels=[]
@@ -249,7 +268,7 @@ class Pipeline:
             ys.append(y)
         tensor_dataset = torch.utils.data.TensorDataset(torch.tensor(x),torch.tensor(y))
         return torch.utils.data.DataLoader(tensor_dataset, batch_size=cfg['batch_size'], shuffle=cfg['shuffle'])
-    
+
     def _embed_loader(self, dataloader, cfg):
         """
         Uses model_instance.predict() to extract embedding tensors and wraps them into a DataLoader.
@@ -259,4 +278,3 @@ class Pipeline:
         x, y = self.model_instance.predict(dataloader)
         tensor_dataset = torch.utils.data.TensorDataset(torch.tensor(x),torch.tensor(y))
         return torch.utils.data.DataLoader(tensor_dataset, batch_size=cfg['batch_size'], shuffle=cfg['shuffle'])
-    


### PR DESCRIPTION
- Implemented an embedding cache for storing representations when only training the decoder
- Changes in `Pipeline.forward` method  to check for data row idx and use of cache enabled in `train_cfg` to use the cache